### PR TITLE
perf: Improve metrics coverage

### DIFF
--- a/batching_kafka_consumer/__init__.py
+++ b/batching_kafka_consumer/__init__.py
@@ -101,14 +101,16 @@ class BatchingKafkaConsumer(object):
         self.worker = worker
 
         self.max_batch_size = max_batch_size
-        self.max_batch_time = max_batch_time
+        self.max_batch_time = max_batch_time  # in milliseconds
         self.metrics = metrics
         self.group_id = group_id
 
         self.shutdown = False
-        self.batch = []
-        self.uncommitted_messages = False
-        self.timer = None
+
+        self.__batch_results  = []
+        self.__batch_deadline = None
+        self.__batch_messages_processed_count = 0
+        self.__batch_messages_processed_duration_ms = 0.0  # in milliseconds
 
         if not isinstance(topics, (list, tuple)):
             topics = [topics]
@@ -192,11 +194,11 @@ class BatchingKafkaConsumer(object):
         self.shutdown = True
 
     def _handle_message(self, msg):
-        self.uncommitted_messages = True
+        start = time.time()
 
-        # start the timer only after the first message for this batch is seen
-        if not self.timer:
-            self.timer = self.max_batch_time / 1000.0 + time.time()
+        # set the deadline only after the first message for this batch is seen
+        if not self.__batch_deadline:
+            self.__batch_deadline = self.max_batch_time / 1000.0 + start
 
         try:
             result = self.worker.process_message(msg)
@@ -218,7 +220,13 @@ class BatchingKafkaConsumer(object):
                 raise
         else:
             if result is not None:
-                self.batch.append(result)
+                self.__batch_results.append(result)
+        finally:
+            duration = (time.time() - start) * 1000
+            self.__batch_messages_processed_count += 1
+            self.__batch_messages_processed_duration_ms += duration
+            if self.metrics:
+                self.metrics.timing('process_message', duration)
 
     def _shutdown(self):
         logger.debug("Stopping")
@@ -235,39 +243,50 @@ class BatchingKafkaConsumer(object):
 
     def _reset_batch(self):
         logger.debug("Resetting in-memory batch")
-        self.uncommitted_messages = False
-        self.batch = []
-        self.timer = None
+        self.__batch_results = []
+        self.__batch_deadline = None
+        self.__batch_messages_processed_count = 0
+        self.__batch_messages_processed_duration_ms = 0.0
 
     def _flush(self, force=False):
         """Decides whether the `BatchingKafkaConsumer` should flush because of either
         batch size or time. If so, delegate to the worker, clear the current batch,
         and commit offsets to Kafka."""
-        if self.uncommitted_messages:
-            batch_by_size = len(self.batch) >= self.max_batch_size
-            batch_by_time = self.timer and time.time() > self.timer
-            if (force or batch_by_size or batch_by_time):
-                logger.info(
-                    "Flushing %s items: forced:%s size:%s time:%s",
-                    len(self.batch), force, batch_by_size, batch_by_time
+        if not self.__batch_messages_processed_count > 0:
+            return  # No messages were processed, so there's nothing to do.
+
+        batch_by_size = len(self.__batch_results) >= self.max_batch_size
+        batch_by_time = self.__batch_deadline and time.time() > self.__batch_deadline
+        if (force or batch_by_size or batch_by_time):
+            logger.info(
+                "Flushing %s items: forced:%s size:%s time:%s",
+                len(self.__batch_results), force, batch_by_size, batch_by_time
+            )
+
+            if self.metrics:
+                self.metrics.timing(
+                    'process_message.normalized',
+                    self.__batch_messages_processed_duration_ms / self.__batch_messages_processed_count,
                 )
 
-                if self.batch:
-                    logger.debug("Flushing batch via worker")
-                    t = time.time()
-                    self.worker.flush_batch(self.batch)
-                    duration = int((time.time() - t) * 1000)
-                    logger.info("Worker flush took %sms", duration)
-                    if self.metrics:
-                        self.metrics.timing('batch.flush', duration)
+            batch_results_length = len(self.__batch_results)
+            if batch_results_length > 0:
+                logger.debug("Flushing batch via worker")
+                flush_start = time.time()
+                self.worker.flush_batch(self.__batch_results)
+                flush_duration = (time.time() - flush_start) * 1000
+                logger.info("Worker flush took %dms", flush_duration)
+                if self.metrics:
+                    self.metrics.timing('batch.flush', flush_duration)
+                    self.metrics.timing('batch.flush.normalized', flush_duration / batch_results_length)
 
-                logger.debug("Committing Kafka offsets")
-                t = time.time()
-                self._commit()
-                duration = int((time.time() - t) * 1000)
-                logger.debug("Kafka offset commit took %sms", duration)
+            logger.debug("Committing Kafka offsets")
+            commit_start = time.time()
+            self._commit()
+            commit_duration = (time.time() - commit_start) * 1000
+            logger.debug("Kafka offset commit took %dms", commit_duration)
 
-                self._reset_batch()
+            self._reset_batch()
 
     def _commit_message_delivery_callback(self, error, message):
         if error is not None:

--- a/batching_kafka_consumer/__init__.py
+++ b/batching_kafka_consumer/__init__.py
@@ -131,7 +131,7 @@ class BatchingKafkaConsumer(object):
         self.commit_log_topic = commit_log_topic
         self.dead_letter_topic = dead_letter_topic
 
-    def __record_timing(self, metric, value, tags=None, sample_rate=None):
+    def __record_timing(self, metric, value, tags=None):
         if self.__metrics is None:
             return
 
@@ -139,7 +139,7 @@ class BatchingKafkaConsumer(object):
             metric,
             value,
             tags=tags,
-            sample_rate=sample_rate if sample_rate is not None else self.__metrics_sample_rates.get(metric, 1),
+            sample_rate=self.__metrics_sample_rates.get(metric, 1),
         )
 
     def create_consumer(self, topics, bootstrap_servers, group_id, auto_offset_reset,


### PR DESCRIPTION
Also renames a few instance and local variables for clarity.

- Adds metric for the time to process an individual event.
- Adds metric for the time to process all events, divided by the number of events processed. This should be useful if/when we add parallel processing to figure out how big of a speedup we're actually getting from parallelizing.
- Adds metric for the time to flush all of the events in a batch.
- Adds metric for the time to flush all of the events in a batch,  divided by the number of events in the batch. This should be helpful to identify if changes to the flush method are making things slower or faster independent from the size of the batch.

This doesn't change the external API.