### PR TITLE
feat: Update dependencies, support Python 3.6 and 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: python
 sudo: required
 dist: xenial
 python:
-  - "2.7"
-  - "3.7"
+  - "3.6"
+  - "3.8"
 cache:
   pip: true
 install:

--- a/Makefile
+++ b/Makefile
@@ -6,3 +6,9 @@ release:
 	python setup.py sdist bdist_wheel
 	twine upload dist/*
 
+install:
+	pip install -e .
+	pip install -r test-requirements.txt
+
+test:
+	py.test tests/

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     packages=find_packages(exclude=("tests", "tests.*")),
     zip_safe=False,
     license="BSD",
-    install_requires=["confluent-kafka==0.11.5"],
+    install_requires=["confluent-kafka==1.5.0"],
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Environment :: Web Environment",
@@ -21,10 +21,9 @@ setup(
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.8",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
 )

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,2 @@
-mock==2.0.0
-pytest==4.0.2
+mock==4.0.3
+pytest==5.2.4


### PR DESCRIPTION
Pytest was so out of date that I couldn't even get the tests to run without upgrading.

Note that this batching-kafka-consumer library isn't currently being used in any part of Sentry.